### PR TITLE
Korrektur beim Auslesen des Kontostandes

### DIFF
--- a/res/ai/TaskBoss.lua
+++ b/res/ai/TaskBoss.lua
@@ -38,7 +38,7 @@ end
 function TaskBoss:BeforeBudgetSetup()
 	self:SetFixedCosts()
 
-	local money = MY.GetCredit()
+	local money = MY.GetMoney()
 	local credit = MY.GetCredit()
 	if (money - credit) > 500000 then	
 		local credit = MY.GetCredit()


### PR DESCRIPTION
Statt des Kontostandes des Spielers wurde die Summe des aktuell aufgenommenen Kredites ausgelesen.